### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/broken_link_checker.yml
+++ b/.github/workflows/broken_link_checker.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '59 07 * * *'  #  UTC 7:59(23:59 PST Winter Time) everyday
 
+permissions:
+  contents: write
+
 jobs:
     link_check:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.